### PR TITLE
Fix mypy errors

### DIFF
--- a/raindrop_cleanup/api/raindrop_client.py
+++ b/raindrop_cleanup/api/raindrop_client.py
@@ -1,7 +1,7 @@
 """Raindrop.io API client for bookmark management."""
 
 import os
-from typing import Any, Optional
+from typing import Any, Optional, Union, cast
 
 import requests
 from requests.exceptions import RequestException
@@ -41,7 +41,8 @@ class RaindropClient:
         try:
             response = requests.get(url, headers=self.headers)
             response.raise_for_status()
-            return response.json().get("items", [])
+            data = cast(dict[str, Any], response.json())
+            return cast(list[dict[str, Any]], data.get("items", []))
         except (RequestException, ValueError) as e:
             print(f"Error fetching collections: {e}")
             return []
@@ -59,7 +60,7 @@ class RaindropClient:
             Dictionary containing bookmarks and pagination info
         """
         url = f"https://api.raindrop.io/rest/v1/raindrops/{collection_id}"
-        params = {
+        params: dict[str, Union[str, int]] = {
             "page": page,
             "perpage": 50,  # Max allowed by API
             "sort": "-created",  # Newest first
@@ -67,7 +68,7 @@ class RaindropClient:
         try:
             response = requests.get(url, headers=self.headers, params=params)
             response.raise_for_status()
-            return response.json()
+            return cast(dict[str, Any], response.json())
         except (RequestException, ValueError) as e:
             print(f"Error fetching bookmarks: {e}")
             return {}

--- a/raindrop_cleanup/cli/main.py
+++ b/raindrop_cleanup/cli/main.py
@@ -2,12 +2,13 @@
 
 import argparse
 import os
-from typing import Optional
+from collections.abc import Sequence
+from typing import Any, Optional
 
 from ..core.processor import RaindropBookmarkCleaner
 
 
-def main():
+def main() -> None:
     """Main CLI entry point."""
     parser = argparse.ArgumentParser(
         description="🌧️  Interactive Raindrop Bookmark Cleanup Tool - AI-powered bookmark curation",
@@ -185,7 +186,7 @@ ADHD-Friendly Features:
         traceback.print_exc()
 
 
-def _handle_resume_selection(sessions) -> Optional[dict]:
+def _handle_resume_selection(sessions: Sequence[dict[str, Any]]) -> Optional[dict[str, Any]]:
     """Handle selection of a resumable session."""
     print("🔄 Choose a session to resume:")
     print("Enter number, or 'new' for a fresh session:")
@@ -206,7 +207,9 @@ def _handle_resume_selection(sessions) -> Optional[dict]:
         print("❌ Invalid choice. Try a number, or 'new' for fresh session.")
 
 
-def _resume_session(cleaner: RaindropBookmarkCleaner, session: dict, args):
+def _resume_session(
+    cleaner: RaindropBookmarkCleaner, session: dict[str, Any], args: argparse.Namespace
+) -> None:
     """Resume a selected session."""
     collections = cleaner.raindrop_client.get_collections()
     selected_collection = None
@@ -240,7 +243,7 @@ def _resume_session(cleaner: RaindropBookmarkCleaner, session: dict, args):
     cleaner.print_stats()
 
 
-def _list_collections(collections):
+def _list_collections(collections: Sequence[dict[str, Any]]) -> None:
     """List all collections."""
     from ..state.manager import StateManager
 
@@ -260,7 +263,7 @@ def _list_collections(collections):
         print(f"  📁 {col['title']} ({count} items{processed_info}) - ID: {col['_id']}")
 
 
-def _select_collection(collections) -> Optional[dict]:
+def _select_collection(collections: Sequence[dict[str, Any]]) -> Optional[dict[str, Any]]:
     """Interactively select a collection to process."""
     from ..state.manager import StateManager
 


### PR DESCRIPTION
## Summary
- add missing type annotations in CLI helpers
- narrow types in raindrop client and cast API responses

## Testing
- `ruff check raindrop_cleanup/cli/main.py raindrop_cleanup/api/raindrop_client.py`
- `mypy raindrop_cleanup`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68850d8301188329847200a31ad9369c