### PR TITLE
Fix state file cleanup, UI counting, and env checks

### DIFF
--- a/raindrop_cleanup/cli/main.py
+++ b/raindrop_cleanup/cli/main.py
@@ -106,6 +106,14 @@ ADHD-Friendly Features:
             "🐛 Debug mode enabled - Claude AI analysis will be logged to .raindrop_debug/"
         )
 
+    # Validate required environment variables early for better UX
+    if not os.getenv("RAINDROP_TOKEN"):
+        print("❌ RAINDROP_TOKEN environment variable not set")
+        return
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        print("❌ ANTHROPIC_API_KEY environment variable not set")
+        return
+
     try:
         cleaner = RaindropBookmarkCleaner(
             dry_run=args.dry_run, text_mode=args.text_mode, debug=debug_mode

--- a/raindrop_cleanup/state/manager.py
+++ b/raindrop_cleanup/state/manager.py
@@ -121,6 +121,9 @@ class StateManager:
             self.stats.update(saved_stats)
             self.stats["start_time"] = datetime.now()  # Reset for this session
 
+            # Track the state file so it can be cleaned up later
+            self.current_state_file = state_file
+
             return state
 
         except (json.JSONDecodeError, KeyError) as e:

--- a/raindrop_cleanup/ui/interfaces.py
+++ b/raindrop_cleanup/ui/interfaces.py
@@ -311,7 +311,11 @@ class UserInterface:
                 elif user_input in ["none", "skip", ""]:
                     return []
                 elif user_input == "all":
-                    return list(range(len(bookmarks)))
+                    return [
+                        i
+                        for i, d in enumerate(decisions)
+                        if d.get("action") != "KEEP"
+                    ]
                 elif user_input == "deletes":
                     return [
                         i

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -81,6 +81,7 @@ class TestStateManager:
         assert loaded_state["collection_name"] == "Unsorted"
         assert state_manager.processed_bookmark_ids == {101, 102, 103}
         assert state_manager.stats["processed"] == 3
+        assert state_manager.current_state_file == state_file
 
     def test_load_state_file_not_found(self, temp_state_dir):
         """Test loading state when file doesn't exist."""

--- a/tests/unit/test_ui_interfaces.py
+++ b/tests/unit/test_ui_interfaces.py
@@ -139,6 +139,25 @@ class TestUserInterface:
 
     @patch("builtins.input")
     @patch("builtins.print")
+    def test_display_text_interface_all_actions_skips_keep(
+        self, mock_print, mock_input, mock_bookmarks
+    ):
+        """Ensure 'all' selection ignores KEEP recommendations."""
+        mock_input.return_value = "all"
+
+        decisions = [
+            {"action": "KEEP", "reasoning": "fine"},
+            {"action": "DELETE", "reasoning": "old"},
+            {"action": "MOVE", "target": "Dev", "reasoning": "prog"},
+        ]
+
+        ui = UserInterface()
+        selected = ui._display_text_interface(mock_bookmarks, decisions)
+
+        assert selected == [1, 2]
+
+    @patch("builtins.input")
+    @patch("builtins.print")
     def test_display_text_interface_deletes_only(
         self, mock_print, mock_input, mock_bookmarks, mock_claude_decisions
     ):


### PR DESCRIPTION
## Summary
- track current state file when resuming so cleanup works
- exclude KEEP actions from `all` selection in text UI
- validate required environment variables early in CLI
- update tests for new behaviour

## Testing
- `ruff check .`
- `mypy raindrop_cleanup`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68851b98a598832995e4a393905cdb3e