### PR TITLE
Fix black format and add agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+This repository uses the development workflow described in `CLAUDE.md`.  When making code changes you should:
+
+* Install dependencies with `pip install -e ".[dev]"`.
+* Format code with **Black** and ensure it passes in check mode.
+* Lint using **ruff**.
+* Type check using **mypy**.
+* Run the unit tests with `pytest`.
+
+All of these checks must succeed before committing.
+
+The project is an AI‑powered bookmark cleanup tool for Raindrop.io built with a modular architecture. The main modules include:
+
+* `api/raindrop_client.py` for Raindrop API access
+* `ai/claude_analyzer.py` for Claude AI integration
+* `ui/interfaces.py` for keyboard and text interfaces
+* `state/manager.py` for persistence of session state
+* `cli/main.py` for the command‑line interface
+
+The test suite under `tests/` uses pytest with extensive mocking of external services.

--- a/raindrop_cleanup/ui/interfaces.py
+++ b/raindrop_cleanup/ui/interfaces.py
@@ -312,9 +312,7 @@ class UserInterface:
                     return []
                 elif user_input == "all":
                     return [
-                        i
-                        for i, d in enumerate(decisions)
-                        if d.get("action") != "KEEP"
+                        i for i, d in enumerate(decisions) if d.get("action") != "KEEP"
                     ]
                 elif user_input == "deletes":
                     return [

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -341,9 +341,10 @@ class TestArgumentParsing:
     @patch("builtins.print")
     def test_missing_env_vars_precheck(self, mock_print):
         """CLI should exit early when required env vars are missing."""
-        with patch.dict(os.environ, {}, clear=True), patch(
-            "raindrop_cleanup.cli.main.RaindropBookmarkCleaner"
-        ) as mock_cleaner:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("raindrop_cleanup.cli.main.RaindropBookmarkCleaner") as mock_cleaner,
+        ):
             main()
 
             mock_cleaner.assert_not_called()


### PR DESCRIPTION
## Summary
- resolve formatting issues caught by Black
- clean up context manager usage in the CLI tests
- create `AGENTS.md` with contributor instructions

## Testing
- `black --check raindrop_cleanup tests`
- `ruff check raindrop_cleanup tests`
- `mypy raindrop_cleanup`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885228f7f8483299582dbf9cfdabc1f