### PR TITLE
Add prompt template loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ The tool is designed for this. It saves state automatically, so you can process 
 
 ### Can I customize the AI prompts?
 
-Not currently through the CLI, but the code is open source. Check the `ai/claude_analyzer.py` module to understand and modify the prompts.
+Yes. Set the `RAINDROP_PROMPT_FILE` environment variable to the path of a text
+file containing your custom prompt template. If the variable is not provided,
+the bundled template at `raindrop_cleanup/ai/default_prompt.txt` is used.
 
 ## 🙏 Acknowledgments
 

--- a/raindrop_cleanup/ai/claude_analyzer.py
+++ b/raindrop_cleanup/ai/claude_analyzer.py
@@ -8,6 +8,8 @@ from typing import Any, Optional
 import anthropic
 from anthropic.types import TextBlock
 
+from .prompt_config import load_prompt_template
+
 
 class ClaudeAnalyzer:
     """Analyzes bookmarks using Claude AI to provide intelligent recommendations."""
@@ -152,74 +154,15 @@ class ClaudeAnalyzer:
             else ""
         )
 
-        return f"""
-You are helping someone with ADHD declutter bookmarks. This person tends to bookmark too much and rarely revisits items. They prefer to re-search rather than keep everything. Be aggressive with DELETE suggestions.
+        template = load_prompt_template()
 
-Analyze these {bookmark_count} bookmarks and provide recommendations:
-{current_collection_info}
-{batch_info}
-
-{collection_info}
-
-ACTIONS:
-- DELETE: Topical blog posts >2 years old, tutorials >5 years old, "someday reading" items, duplicate content
-- KEEP: Already in correct collection, timeless references, active work tools
-- ARCHIVE: Historical reference (if Archive collection exists)
-- MOVE:[CollectionName]: Should be in different collection for better organization
-
-CRITICAL RULES:
-- NEVER suggest MOVE to current collection ({current_collection_name}) - use KEEP instead
-- DEFAULT to MOVE for better organization over KEEP
-- Be ruthless with DELETE - user can find things via search
-- When uncertain between KEEP/DELETE, lean toward DELETE
-- User rarely revisits bookmarks, so DELETE liberally
-
-AGE-BASED DELETE RULES:
-- News articles, topical blog posts: DELETE if >2 years old
-- Tutorials, how-tos: DELETE if >5 years old (unless timeless)
-- Medium articles: DELETE if >3 years old
-- GitHub repos: DELETE if archived/abandoned
-
-SPECIFIC COLLECTION MAPPING:
-- reddit.com/r/programming → development
-- docs.microsoft.com → development (and KEEP)
-- news.ycombinator.com → reading-and-blogs
-- medium.com articles → reading-and-blogs (or DELETE if old)
-- GitHub repos → development
-- Gaming content → gaming
-- Apple-specific → apple
-- Security topics → privacy-security
-- Linux/Unix → linux-unix
-- Text editors → text-editors
-- Infrastructure/DevOps → infrastructure
-- OpenBSD → openbsd
-- Health topics → health-wellness
-- Music → music
-- Making/DIY → making
-- AI/ML → ai-ml
-- Tools/utilities → tools
-- RSS/bookmarking → bookmarking-and-rss
-- Emacs → emacs
-- Work items → work-specific
-
-EXAMPLE DECISIONS:
-1. "React Hooks Tutorial" (2019) + react.dev → DELETE - 5+ year old tutorial, React has changed significantly
-2. "Microsoft Azure Documentation" + docs.microsoft.com → KEEP - timeless reference in correct collection
-3. "Interesting AI article" + medium.com (2021) → DELETE - 3+ year old Medium article, likely outdated
-4. "Vim Configuration Guide" + reddit.com/r/vim → MOVE:text-editors - better organization
-5. "Apple M1 Review" (2020) + arstechnica.com → DELETE - 4+ year old tech review, outdated
-6. "Python requests library docs" + docs.python.org → MOVE:development - reference documentation
-7. "Weekend project ideas" + personal blog (2019) → DELETE - 5+ year old someday reading
-
-Respond with ONLY the numbers and decisions:
-1. DELETE - outdated tutorial from 2019
-2. MOVE:development - coding reference
-3. KEEP - timeless documentation
-4. DELETE - old topical article
-etc.
-
-Include specific reasoning focusing on age, relevance, and collection fit.
-"""
+        return template.format(
+            bookmark_count=bookmark_count,
+            current_collection_name=current_collection_name or "",
+            batch_info=batch_info,
+            collection_info=collection_info,
+            current_collection_info=current_collection_info,
+        )
 
     def _parse_batch_response(
         self, message: str, bookmark_count: int

--- a/raindrop_cleanup/ai/default_prompt.txt
+++ b/raindrop_cleanup/ai/default_prompt.txt
@@ -1,0 +1,66 @@
+You are helping someone with ADHD declutter bookmarks. This person tends to bookmark too much and rarely revisits items. They prefer to re-search rather than keep everything. Be aggressive with DELETE suggestions.
+
+Analyze these {bookmark_count} bookmarks and provide recommendations:
+{current_collection_info}
+{batch_info}
+
+{collection_info}
+
+ACTIONS:
+- DELETE: Topical blog posts >2 years old, tutorials >5 years old, "someday reading" items, duplicate content
+- KEEP: Already in correct collection, timeless references, active work tools
+- ARCHIVE: Historical reference (if Archive collection exists)
+- MOVE:[CollectionName]: Should be in different collection for better organization
+
+CRITICAL RULES:
+- NEVER suggest MOVE to current collection ({current_collection_name}) - use KEEP instead
+- DEFAULT to MOVE for better organization over KEEP
+- Be ruthless with DELETE - user can find things via search
+- When uncertain between KEEP/DELETE, lean toward DELETE
+- User rarely revisits bookmarks, so DELETE liberally
+
+AGE-BASED DELETE RULES:
+- News articles, topical blog posts: DELETE if >2 years old
+- Tutorials, how-tos: DELETE if >5 years old (unless timeless)
+- Medium articles: DELETE if >3 years old
+- GitHub repos: DELETE if archived/abandoned
+
+SPECIFIC COLLECTION MAPPING:
+- reddit.com/r/programming → development
+- docs.microsoft.com → development (and KEEP)
+- news.ycombinator.com → reading-and-blogs
+- medium.com articles → reading-and-blogs (or DELETE if old)
+- GitHub repos → development
+- Gaming content → gaming
+- Apple-specific → apple
+- Security topics → privacy-security
+- Linux/Unix → linux-unix
+- Text editors → text-editors
+- Infrastructure/DevOps → infrastructure
+- OpenBSD → openbsd
+- Health topics → health-wellness
+- Music → music
+- Making/DIY → making
+- AI/ML → ai-ml
+- Tools/utilities → tools
+- RSS/bookmarking → bookmarking-and-rss
+- Emacs → emacs
+- Work items → work-specific
+
+EXAMPLE DECISIONS:
+1. "React Hooks Tutorial" (2019) + react.dev → DELETE - 5+ year old tutorial, React has changed significantly
+2. "Microsoft Azure Documentation" + docs.microsoft.com → KEEP - timeless reference in correct collection
+3. "Interesting AI article" + medium.com (2021) → DELETE - 3+ year old Medium article, likely outdated
+4. "Vim Configuration Guide" + reddit.com/r/vim → MOVE:text-editors - better organization
+5. "Apple M1 Review" (2020) + arstechnica.com → DELETE - 4+ year old tech review, outdated
+6. "Python requests library docs" + docs.python.org → MOVE:development - reference documentation
+7. "Weekend project ideas" + personal blog (2019) → DELETE - 5+ year old someday reading
+
+Respond with ONLY the numbers and decisions:
+1. DELETE - outdated tutorial from 2019
+2. MOVE:development - coding reference
+3. KEEP - timeless documentation
+4. DELETE - old topical article
+etc.
+
+Include specific reasoning focusing on age, relevance, and collection fit.

--- a/raindrop_cleanup/ai/prompt_config.py
+++ b/raindrop_cleanup/ai/prompt_config.py
@@ -1,0 +1,29 @@
+"""Utilities for loading AI prompt templates."""
+
+from __future__ import annotations
+
+import os
+from importlib import resources
+
+
+def load_prompt_template() -> str:
+    """Return the prompt template text.
+
+    If the ``RAINDROP_PROMPT_FILE`` environment variable is set, the template is
+    loaded from that file path. Otherwise the bundled ``default_prompt.txt`` is
+    used.
+    """
+    env_path = os.getenv("RAINDROP_PROMPT_FILE")
+    if env_path:
+        try:
+            with open(env_path, encoding="utf-8") as f:
+                return f.read()
+        except OSError:
+            pass
+
+    with (
+        resources.files(__package__)
+        .joinpath("default_prompt.txt")
+        .open("r", encoding="utf-8") as f
+    ):
+        return f.read()

--- a/tests/unit/test_claude_analyzer.py
+++ b/tests/unit/test_claude_analyzer.py
@@ -7,6 +7,7 @@ import pytest
 from anthropic.types import TextBlock
 
 from raindrop_cleanup.ai.claude_analyzer import ClaudeAnalyzer
+from raindrop_cleanup.ai.prompt_config import load_prompt_template
 
 
 class TestClaudeAnalyzer:
@@ -96,11 +97,16 @@ class TestClaudeAnalyzer:
             batch_info, collection_info, 1, "Development"
         )
 
-        assert "helping someone with ADHD" in prompt
-        assert "CURRENT COLLECTION: Development" in prompt
-        assert batch_info in prompt
-        assert collection_info in prompt
-        assert "NEVER suggest MOVE to current collection (Development)" in prompt
+        template = load_prompt_template()
+        expected = template.format(
+            bookmark_count=1,
+            current_collection_name="Development",
+            batch_info=batch_info,
+            collection_info=collection_info,
+            current_collection_info="\nCURRENT COLLECTION: Development\n",
+        )
+
+        assert prompt == expected
 
     def test_parse_batch_response_valid_responses(self, mock_anthropic_client):
         """Test parsing valid Claude responses."""


### PR DESCRIPTION
## Summary
- add helper to read AI prompt from default file or custom path via `RAINDROP_PROMPT_FILE`
- move default prompt text to `default_prompt.txt`
- update Claude analyzer to use the loader and format template
- update unit tests for new loading logic
- document customization in README

## Testing
- `black --check .`
- `ruff check .`
- `mypy raindrop_cleanup`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68855f25f39c83299b746b60b70ab2e0